### PR TITLE
_id must not be null.

### DIFF
--- a/lib/Couch/DB/Document.pm
+++ b/lib/Couch/DB/Document.pm
@@ -311,7 +311,8 @@ sub create($%)
 	$query{batch} = 'ok'
 		if exists $args{batch} ? delete $args{batch} : $self->batch;
 
-	$data->{_id} ||= $self->id;
+	$data->{_id} ||= $self->id
+		if defined $self->id;
 
 	$self->couch->call(POST => $self->db->_pathToDB,  # !!
 		send     => $data,


### PR DESCRIPTION
To get a _id from couchdb, _id must not be set to null (undef), but must be a string. 