### PR TITLE
Improvements for indexFind() usability and paging behavior

### DIFF
--- a/lib/Couch/DB/Design.pm
+++ b/lib/Couch/DB/Design.pm
@@ -40,6 +40,7 @@ M<Couch::DB::Document>.
 =cut
 
 sub _pathToDoc(;$) { $_[0]->db->_pathToDB('_design/' . $_[0]->id) . (defined $_[1] ? '/' . uri_escape $_[1] : '')  }
+sub _pathToDDoc(;$) { $_[0]->db->_pathToDB('_design/' . $_[0]->id) . (defined $_[1] ? '/' . $_[1] : '')  }
 
 #-------------
 =section Document in the database
@@ -201,7 +202,7 @@ sub indexFind($%)
 		->toQuery($query, int  => qw/highlight_number highlight_size limit/)
 		->toQuery($query, bool => qw/include_docs/);
 
-	$couch->call(GET => $self->_pathToDDoc('_search/' . uri_escape $index),
+	$couch->call(GET => $self->_pathToDDoc('_search/' . $index),
 		introduced => '3.0.0',
 		query      => $query,
 		$couch->_resultsPaging(\%args,

--- a/lib/Couch/DB/Mojolicious.pm
+++ b/lib/Couch/DB/Mojolicious.pm
@@ -113,7 +113,7 @@ sub _callClient($$%)
 	});
 
 	if($delay)
-	{	$result->setResultDelay({ client => $client });
+	{	$result->setResultDelayed({ client => $client });
 	}
 	else
 	{	$plan->wait;

--- a/lib/Couch/DB/Result.pm
+++ b/lib/Couch/DB/Result.pm
@@ -206,7 +206,7 @@ sub answer(%)
  	$self->isReady
 		or error __x"Document not ready: {err}", err => $self->message;
 
-	$self->{CDR_answer} = $self->couch->_extractAnswer($self->response),
+	$self->{CDR_answer} = $self->couch->_extractAnswer($self->response);
 }
 
 =method values
@@ -258,7 +258,16 @@ sub pagingState(%)
 # The next is used r/w when _succeed is a result object, and when results
 # have arrived.
 
-sub _thisPage() { $_[0]->{CDR_page} or panic "Call does not support paging." }
+sub _thisPage()
+{ my $this = $_[0]->{CDR_page} or panic "Call does not support paging.";
+	# Häßlicher Workaround, oder Lösung?
+	if (exists($_[0]->{CDR_answer}->{total_rows})) {
+		if (@{$this->{harvested}} >= $_[0]->{CDR_answer}->{total_rows}) {
+			$this->{end_reached} = 1;
+		}
+	}
+	$this;
+}
 
 =method nextPageSettings
 Returns the details for the next page to be collected.  When you need these


### PR DESCRIPTION
### Summary

Made several changes to make the following code work as expected:

```
use Couch::DB::Mojolicious ();
my $couch   = Couch::DB::Mojolicious->new(api => $ENV{_Couch_DB_API} // '3.3.3');
my $client  = $couch->createClient(server => $ENV{PERL_COUCH_DB_SERVER});
my $db = $client->db($ENV{_Couch_DB_DB});
my $ddoc = Couch::DB::Design->new(db=>$db, id=>"ndb");

my $list;
my $max = 10;
my $cnt = 0;
while($list = $ddoc->indexFind("ndbSearch", search => {query => 'TEMPLATE:network-element', include_docs=>1}, _page_size => 25, _succeed => $list))
{
    $cnt++;
    last if $cnt > $max;
    my $_docs = $list->page;
    @$_docs or last;    # nothing left

    for my $h ($_docs->@*) {
        say 'hostname: ',  $h->{doc}{attr}{hostname}[0] // '_undef_ in ' . $h->{doc}{_id};
    }
}
```

### Changes

- Fixed: Correct handling of paging – properly terminate if more results than total_rows
- Fixed: Several typos in method names
- Fixed: Removed unnecessary uri_escape calls
- Fixed: Correctly merged paging parameters into GET requests

### Notes
With these fixes, indexFind() is now usable for me in practical code (see example above).
Paging and result handling behave as expected.